### PR TITLE
hotfix: lower numpy requirement from 2.0 to 1.25 to allow biotite ins…

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Bio-Informatics",
 ]
 dependencies = [
-  "numpy >= 2.0",
+  "numpy >= 1.25",
   "scipy >= 1.13",
 ]
 dynamic = ["version"]


### PR DESCRIPTION
Hi @padix-key -- 
here's a quick hotfix to lower the version requirement for numpy to 1.25, as it otherwise leads to a version conflict when installing the latest biotite v1.0.0 release
(c.f. https://github.com/biotite-dev/biotite/blob/main/pyproject.toml#L25-L26) 